### PR TITLE
Update httpclient related code

### DIFF
--- a/nude-akka/src/main/java/gov/usgs/cida/nude/plan/ConnectorPlanStep.java
+++ b/nude-akka/src/main/java/gov/usgs/cida/nude/plan/ConnectorPlanStep.java
@@ -42,7 +42,10 @@ import scala.concurrent.duration.FiniteDuration;
 /**
  * [UNIT-TESTABLE]?
  * @author dmsibley
+ * 
+ * Not used in EnDDaT at this time - perhaps elsewhere? Remove @Deprecated if a use is found.
  */
+@Deprecated
 public class ConnectorPlanStep implements PlanStep {
 	private static final Logger log = LoggerFactory.getLogger(ConnectorPlanStep.class);
 	private final List<IConnector> connectors;

--- a/nude/src/main/java/gov/usgs/cida/nude/provider/IProvider.java
+++ b/nude/src/main/java/gov/usgs/cida/nude/provider/IProvider.java
@@ -4,8 +4,9 @@ public interface IProvider {
 	
 	/**
 	 * Call this before you start.
+	 * @throws InterruptedException 
 	 */
-	public void init();
+	public void init() throws InterruptedException;
 	
 	/**
 	 * Always call this when you're done!

--- a/nude/src/main/java/gov/usgs/cida/nude/provider/http/IdleConnectionMonitorThread.java
+++ b/nude/src/main/java/gov/usgs/cida/nude/provider/http/IdleConnectionMonitorThread.java
@@ -1,0 +1,41 @@
+package gov.usgs.cida.nude.provider.http;
+
+import java.util.concurrent.TimeUnit;
+
+import org.apache.http.conn.HttpClientConnectionManager;
+import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
+
+public class IdleConnectionMonitorThread extends Thread {
+	private final HttpClientConnectionManager connMgr;
+	private final int idleTimeMilliSeconds;
+	private volatile boolean shutdown;
+
+	public IdleConnectionMonitorThread(PoolingHttpClientConnectionManager connMgr, int idleTimeMilliSeconds) {
+		super();
+		this.connMgr = connMgr;
+		this.idleTimeMilliSeconds = idleTimeMilliSeconds;
+	}
+
+	@Override
+	public void run() {
+		try {
+			while (!shutdown) {
+				synchronized (this) {
+					wait(idleTimeMilliSeconds);
+					connMgr.closeExpiredConnections();
+					connMgr.closeIdleConnections(idleTimeMilliSeconds, TimeUnit.MILLISECONDS);
+				}
+			}
+		} catch (InterruptedException ex) {
+			shutdown();
+		}
+	}
+
+	public void shutdown() {
+		shutdown = true;
+		synchronized (this) {
+			notifyAll();
+		}
+	}
+
+}


### PR DESCRIPTION
The deprecated httpclient code we were using does not handle SNI. Updated to the replacement modules for SNI support. This includes a couple of "finally" blocks to release the connection resources.

Based on WQP experience, the IdleConnectionMonitorThread was also added to kill any hanging connections which managed to not be cleaned up correctly.

Not sure why the ENDDAT-184 commit didn't make the last cut, but it looks harmless. 