### PR TITLE
Revert SimpleColumn upper-casing. Added holdable connection creation …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /nude-akka/target/
 /nude/target/
 /.project
+**/.vscode

--- a/nude/src/main/java/gov/usgs/cida/nude/column/SimpleColumn.java
+++ b/nude/src/main/java/gov/usgs/cida/nude/column/SimpleColumn.java
@@ -24,9 +24,9 @@ public class SimpleColumn implements Column, Serializable {
 	}
 	
 	public SimpleColumn(String column, String table, String schema, Class<?> type, boolean isDisplayable) {
-		this.columnName = (StringUtils.isNotBlank(column))?column.toUpperCase():"";
+		this.columnName = (StringUtils.isNotBlank(column))?column:"";
 		this.tableName = "";
-		this.schemaName = (StringUtils.isNotBlank(schema))?schema.toUpperCase():"";
+		this.schemaName = (StringUtils.isNotBlank(schema))?schema:"";
 		this.valueType = type;
 		this.isDisplay = isDisplayable;
 	}

--- a/nude/src/main/java/gov/usgs/cida/nude/provider/sql/SQLProvider.java
+++ b/nude/src/main/java/gov/usgs/cida/nude/provider/sql/SQLProvider.java
@@ -42,6 +42,18 @@ public class SQLProvider implements IProvider {
 		
 		log.trace("Initialized SQLProvider " + this.hashCode());
 	}
+
+	public Connection getHoldableConnection(UUID requestId) throws SQLException, NamingException, ClassNotFoundException {
+		Connection result = getConnection(requestId);
+
+		try {
+			result.setHoldability(ResultSet.HOLD_CURSORS_OVER_COMMIT);
+		} catch (SQLFeatureNotSupportedException e) {
+			log.warn("Unable to get holdable connection. Exception: ", e);
+		}
+
+		return result;
+	}
 	
 	public Connection getConnection(UUID requestId) throws SQLException, NamingException, ClassNotFoundException {
 		Connection result = null;

--- a/nude/src/main/java/gov/usgs/cida/nude/provider/sql/SQLProvider.java
+++ b/nude/src/main/java/gov/usgs/cida/nude/provider/sql/SQLProvider.java
@@ -49,7 +49,8 @@ public class SQLProvider implements IProvider {
 		try {
 			result.setHoldability(ResultSet.HOLD_CURSORS_OVER_COMMIT);
 		} catch (SQLFeatureNotSupportedException e) {
-			log.warn("Unable to get holdable connection. Exception: ", e);
+			log.error("Unable to get holdable connection. Exception: ", e);
+			throw e;
 		}
 
 		return result;


### PR DESCRIPTION
…method.

Reverts upper-casing from #8 (case logic moved over to GCMRC itself). After spending all day debugging through NUDE and GCMRC I came up with a solution to the issues GCMRC was seeing in Postgres.

None of the classes here in NUDE actually initiate the connection to the DB, hence I figured the logic for transforming Column names shouldn't be in here. The actual NUDE step that does the DB connection in GCMRC is defined in GCMRC itself, and the stuff here can work with whatever column names are given, as long as the provided names match the names in the provided ResultSet. I decided to continue with the pattern of requiring the application using the library to ensure that it provides a set of Column names which match the names in the provided ResultSet.

Additionally, this PR adds a method for creating holdable connections. In Oracle (at least the version we were using) cursors created in connections would hold across `commit()` calls. In Postgres, by default created cursors are destroyed after `commit()` calls, unless you create the connection with the `holdable` attribute defined. Thus I created a separate method for initiating a holdable connection, that can be used when an application using Postgres needs its cursor to persist across `commit()` calls.